### PR TITLE
Add toggle control for sidebar visibility

### DIFF
--- a/popup/popup.html
+++ b/popup/popup.html
@@ -298,13 +298,13 @@
             <input type="checkbox" id="sidebarPinned" />
             <span class="toggle-switch"></span>
             <span class="toggle-text">
-              <strong>Show sidebar by default</strong>
-              <small>Display saved searches sidebar when you visit X.com</small>
+              <strong>Show Sidebar</strong>
+              <small>Display saved searches sidebar on X.com</small>
             </span>
           </label>
         </div>
         <div class="setting-info">
-          <p>💡 You can always toggle the sidebar using the arrow button on the right side of X.com</p>
+          <p>💡 You can also toggle the sidebar using the arrow button on the right side of X.com</p>
         </div>
       </div>
 

--- a/tests/e2e/workflows/settings.spec.ts
+++ b/tests/e2e/workflows/settings.spec.ts
@@ -72,7 +72,7 @@ test.describe('Settings Management', () => {
     await expect(toggleSwitch).toBeVisible();
 
     const toggleText = page.locator('.toggle-text strong');
-    await expect(toggleText).toHaveText('Show sidebar by default');
+    await expect(toggleText).toHaveText('Show Sidebar');
 
     const toggleDescription = page.locator('.toggle-text small');
     await expect(toggleDescription).toContainText('Display saved searches sidebar');


### PR DESCRIPTION
- Add "Show Sidebar" toggle in popup settings (defaults to ON)
- Settings toggle removes/adds sidebar from DOM via message handler
- On-screen toggle (arrow button) hides/shows with CSS only
- Sidebar always initializes on page load (may be hidden via CSS)
- Update settings test assertions for new UI text
- Fix E2E test failures caused by persistent storage state

