### PR TITLE
Add info icon with hover tooltip to keywords input

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -142,7 +142,10 @@ async function initializeSidebar() {
         <div class="sidebar-tab-content" id="builderTab">
           <form id="sidebarSearchForm">
             <section class="form-section">
-              <h3>Keywords</h3>
+              <h3>
+                Keywords
+                <span class="info-icon" title="Keywords use X's search - case-sensitive, respects punctuation">ℹ️</span>
+              </h3>
               <input type="text" id="sidebarKeywords" placeholder='e.g., "claude code"' />
             </section>
 

--- a/content/sidebar.css
+++ b/content/sidebar.css
@@ -480,6 +480,22 @@
   font-weight: 600;
   color: #e7e9ea;
   margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.info-icon {
+  font-size: 14px;
+  cursor: help;
+  opacity: 0.6;
+  transition: opacity 0.2s;
+  display: inline-flex;
+  align-items: center;
+}
+
+.info-icon:hover {
+  opacity: 1;
 }
 
 .section-header {


### PR DESCRIPTION
Adds an info icon with hover tooltip to the keywords input in the sidebar builder tab.

## Changes
- Added info icon (ℹ️) next to "Keywords" heading
- Icon displays tooltip: "Keywords use X's search - case-sensitive, respects punctuation"
- Added CSS styles for proper hover behavior

Fixes #17

Generated with [Claude Code](https://claude.ai/code)