### PR TITLE
Improve visibility of Save and Reset buttons in sidebar builder

### DIFF
--- a/content/sidebar.css
+++ b/content/sidebar.css
@@ -733,25 +733,30 @@
 }
 
 .btn-secondary {
-  background: transparent;
-  color: #e7e9ea;
-  border: 1px solid #2f3336;
+  background: #1d9bf0;
+  color: white;
+  border: 1px solid #1d9bf0;
 }
 
 .btn-secondary:hover {
-  background: #16181c;
-  border-color: #3d4147;
+  background: #1a8cd8;
+  border-color: #1a8cd8;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(29, 155, 240, 0.3);
 }
 
 .btn-text {
-  background: transparent;
-  color: #71767b;
+  background: rgba(255, 255, 255, 0.08);
+  color: #e7e9ea;
+  border: 1px solid #3d4147;
   flex: 0.5;
 }
 
 .btn-text:hover {
-  color: #e7e9ea;
-  background: #16181c;
+  color: #ffffff;
+  background: rgba(255, 255, 255, 0.15);
+  border-color: #4d5157;
+  transform: translateY(-1px);
 }
 
 .setting-info {


### PR DESCRIPTION
## Summary

This PR improves the visibility of the Save Search and Reset buttons in the builder sidebar by updating their colors and styling.

## Changes

- **Save Search button**: Changed from transparent with subtle border to bright blue (#1d9bf0) with white text
- **Reset button**: Enhanced with semi-transparent white background and brighter text contrast
- Both buttons now have smooth hover effects with subtle lift animations

Fixes #18

🤖 Generated with [Claude Code](https://claude.ai/code)