### PR TITLE
Add enhanced time window explainer to sidebar builder

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -193,7 +193,7 @@ async function initializeSidebar() {
                   </select>
                 </div>
                 <div class="setting-info" id="sidebarSlidingWindowInfo" style="display: none; margin-top: 8px;">
-                  <p style="font-size: 11px; color: #6b7280;">🕒 This search will automatically update to show posts from the selected time window whenever you use it.</p>
+                  <p style="font-size: 11px; color: #6b7280; line-height: 1.4;">🕒 <strong>Dynamic time range:</strong> This search automatically updates each time you use it. For example, "Last 1 Week" always shows posts from the past 7 days starting from today. Unlike X's fixed date ranges, this always returns fresh, recent content.</p>
                 </div>
               </div>
             </section>


### PR DESCRIPTION
## Summary
Added an enhanced explainer to the Time Window section in the sidebar's Builder tab.

## Changes
- Updated the info text to clearly explain that dynamic time ranges update automatically
- Added concrete example showing how "Last 1 Week" always shows past 7 days from current day
- Highlighted the difference from X's fixed date ranges
- Improved text formatting with better line-height for readability

Resolves #19

🤖 Generated with [Claude Code](https://claude.ai/code)