### PR TITLE
Remove date preset buttons from sidebar date range section

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -212,11 +212,6 @@ async function initializeSidebar() {
                   <label>Until</label>
                   <input type="date" id="sidebarUntilDate" />
                 </div>
-                <div class="date-presets">
-                  <button type="button" class="preset-btn" data-preset="today">Today</button>
-                  <button type="button" class="preset-btn" data-preset="week">Last Week</button>
-                  <button type="button" class="preset-btn" data-preset="month">Last Month</button>
-                </div>
               </div>
             </section>
 
@@ -780,7 +775,6 @@ let editingSidebarSearchId = null;
 function initializeSidebarBuilder() {
   initializeSidebarCollapsibleSections();
   initializeSidebarDefaultDates();
-  initializeSidebarDatePresets();
   initializeSidebarSlidingWindow();
   initializeSidebarFormListeners();
   initializeSidebarBuilderButtons();
@@ -813,42 +807,6 @@ function initializeSidebarDefaultDates() {
     untilDate.value = today.toISOString().split('T')[0];
     updateSidebarQueryPreview();
   }
-}
-
-function initializeSidebarDatePresets() {
-  const presetButtons = document.querySelectorAll('#builderTab .preset-btn');
-  presetButtons.forEach(btn => {
-    btn.addEventListener('click', () => {
-      const slidingWindowSelect = document.getElementById('sidebarSlidingWindow');
-
-      if (slidingWindowSelect && slidingWindowSelect.value) {
-        slidingWindowSelect.value = '';
-        toggleSidebarDateInputs();
-      }
-
-      const preset = btn.dataset.preset;
-      const today = new Date();
-      const sinceDate = document.getElementById('sidebarSinceDate');
-
-      switch(preset) {
-        case 'today':
-          sinceDate.value = today.toISOString().split('T')[0];
-          break;
-        case 'week':
-          const weekAgo = new Date(today);
-          weekAgo.setDate(weekAgo.getDate() - 7);
-          sinceDate.value = weekAgo.toISOString().split('T')[0];
-          break;
-        case 'month':
-          const monthAgo = new Date(today);
-          monthAgo.setMonth(monthAgo.getMonth() - 1);
-          sinceDate.value = monthAgo.toISOString().split('T')[0];
-          break;
-      }
-
-      updateSidebarQueryPreview();
-    });
-  });
 }
 
 function initializeSidebarSlidingWindow() {
@@ -901,7 +859,6 @@ function toggleSidebarDateInputs() {
   const slidingWindowValue = document.getElementById('sidebarSlidingWindow')?.value;
   const sinceDateInput = document.getElementById('sidebarSinceDate');
   const untilDateInput = document.getElementById('sidebarUntilDate');
-  const presetButtons = document.querySelectorAll('#builderTab .preset-btn');
   const slidingWindowInfo = document.getElementById('sidebarSlidingWindowInfo');
 
   if (!sinceDateInput || !untilDateInput) return;
@@ -913,10 +870,6 @@ function toggleSidebarDateInputs() {
     untilDateInput.style.opacity = '0.5';
     sinceDateInput.style.cursor = 'pointer';
     untilDateInput.style.cursor = 'pointer';
-    presetButtons.forEach(btn => {
-      btn.style.opacity = '0.5';
-      btn.style.cursor = 'pointer';
-    });
     if (slidingWindowInfo) slidingWindowInfo.style.display = 'block';
   } else {
     sinceDateInput.readOnly = false;
@@ -925,10 +878,6 @@ function toggleSidebarDateInputs() {
     untilDateInput.style.opacity = '1';
     sinceDateInput.style.cursor = '';
     untilDateInput.style.cursor = '';
-    presetButtons.forEach(btn => {
-      btn.style.opacity = '1';
-      btn.style.cursor = '';
-    });
     if (slidingWindowInfo) slidingWindowInfo.style.display = 'none';
   }
 }

--- a/tests/e2e/workflows/create-save-search.spec.ts
+++ b/tests/e2e/workflows/create-save-search.spec.ts
@@ -38,30 +38,6 @@ test.describe('Workflow 1: Create & Save Search', () => {
     await page.close();
   });
 
-  test('should use date presets correctly', async ({ context, extensionId: _extensionId }) => {
-    const page = await context.newPage();
-    const testPageHelper = new TestPageHelpers(page);
-
-    await testPageHelper.navigateToTestPage();
-    await page.waitForTimeout(1000);
-
-    const sidebar = new SidebarPage(page);
-    await sidebar.waitForInjection(5000);
-    await sidebar.ensureVisible();
-
-    await sidebar.fillKeywords('news');
-    await sidebar.clickDatePreset('today');
-
-    const preview = await sidebar.getQueryPreview();
-    expect(preview).toContain('since:');
-
-    const today = new Date().toISOString().split('T')[0];
-    expect(preview).toContain(today);
-
-    await page.waitForTimeout(1000);
-    await page.close();
-  });
-
   test('should reset form correctly', async ({ context, extensionId: _extensionId }) => {
     const page = await context.newPage();
     const testPageHelper = new TestPageHelpers(page);

--- a/tests/e2e/workflows/date-picker.spec.ts
+++ b/tests/e2e/workflows/date-picker.spec.ts
@@ -264,34 +264,6 @@ test.describe('Workflow: Date Picker Calendar', () => {
     await page.close();
   });
 
-  test('should work with date presets after manual date entry', async ({ context, extensionId: _extensionId }) => {
-    const page = await context.newPage();
-    const testPageHelper = new TestPageHelpers(page);
-
-    await testPageHelper.navigateToTestPage();
-    await page.waitForTimeout(1000);
-
-    const sidebar = new SidebarPage(page);
-    await sidebar.waitForInjection(5000);
-    await sidebar.ensureVisible();
-    await sidebar.switchTab('builder');
-
-    // Manually set dates
-    await sidebar.setDateRange('2020-01-01', '2020-12-31');
-    await page.waitForTimeout(500);
-
-    // Click a date preset
-    await sidebar.clickDatePreset('today');
-    await page.waitForTimeout(500);
-
-    // Verify since date updated to today
-    const sinceValue = await page.locator('#sidebarSinceDate').inputValue();
-    const today = new Date().toISOString().split('T')[0];
-    expect(sinceValue).toBe(today);
-
-    await page.close();
-  });
-
   test('should maintain date values when switching tabs', async ({ context, extensionId: _extensionId }) => {
     const page = await context.newPage();
     const testPageHelper = new TestPageHelpers(page);

--- a/tests/e2e/workflows/sliding-window.spec.ts
+++ b/tests/e2e/workflows/sliding-window.spec.ts
@@ -104,38 +104,6 @@ test.describe('Sliding Window Feature', () => {
       await page.close();
     });
 
-    test('should clear sliding window when date preset is clicked', async ({ context, extensionId: _extensionId }) => {
-      const page = await context.newPage();
-      const testPageHelper = new TestPageHelpers(page);
-      await testPageHelper.navigateToTestPage();
-      await page.waitForTimeout(1000);
-
-      const sidebar = new SidebarPage(page);
-      await sidebar.waitForInjection(5000);
-      await sidebar.ensureVisible();
-      await sidebar.switchTab('builder');
-      await page.waitForTimeout(1000);
-
-      // Select sliding window
-      await sidebar.selectSlidingWindow('1m');
-      expect(await sidebar.getSlidingWindowValue()).toBe('1m');
-
-      // Click a date preset (the click handler will clear sliding window first, then set the date)
-      await sidebar.clickDatePreset('today');
-      await page.waitForTimeout(500);
-
-      // Sliding window should be cleared
-      expect(await sidebar.getSlidingWindowValue()).toBe('');
-      expect(await sidebar.areDateInputsEnabled()).toBe(true);
-
-      // Verify the preset date was applied
-      const sinceValue = await sidebar.getSinceDateValue();
-      const today = new Date().toISOString().split('T')[0];
-      expect(sinceValue).toBe(today);
-
-      await page.close();
-    });
-
     test('should show calculated dates in query preview for sliding window', async ({ context, extensionId: _extensionId }) => {
       const page = await context.newPage();
       const testPageHelper = new TestPageHelpers(page);

--- a/tests/page-objects/SidebarPage.ts
+++ b/tests/page-objects/SidebarPage.ts
@@ -162,10 +162,6 @@ export class SidebarPage {
     }
   }
 
-  async clickDatePreset(preset: 'today' | 'week' | 'month') {
-    await this.page.click(`#builderTab .preset-btn[data-preset="${preset}"]`);
-  }
-
   async getSinceDateValue(): Promise<string> {
     return await this.page.locator('#sidebarSinceDate').inputValue();
   }


### PR DESCRIPTION
## Summary

Removes the 'Today', 'Last Week', and 'Last Month' buttons from the Date Range section in the sidebar search builder as requested in #21.

## Changes

- Removed date-presets div with three preset buttons from HTML
- Removed `initializeSidebarDatePresets()` function (35 lines)
- Cleaned up `toggleSidebarDateInputs()` by removing preset button references
- Removed function call from `initializeSidebarBuilder()`

**Total:** 51 lines removed from `content/content.js`

## Notes

Users can still manually enter dates or use the dynamic Time Window feature for sliding date ranges.

Closes #21

🤖 Generated with [Claude Code](https://claude.ai/code)