### PR TITLE
Add hover info icon to Date Range section

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -201,6 +201,7 @@ async function initializeSidebar() {
             <section class="form-section collapsible">
               <h3 class="section-header">
                 Date Range
+                <span class="info-icon" title="Sets a fixed time period. For dynamic dates that auto-update, use the Time Window feature above.">ℹ️</span>
                 <span class="toggle-icon">▼</span>
               </h3>
               <div class="section-content">

--- a/content/sidebar.css
+++ b/content/sidebar.css
@@ -1112,3 +1112,16 @@
 .about-creator a:hover {
   text-decoration: underline;
 }
+
+/* Info icon tooltip */
+.info-icon {
+  font-size: 14px;
+  color: #71767b;
+  cursor: help;
+  margin-left: 6px;
+  transition: color 0.2s;
+}
+
+.info-icon:hover {
+  color: #1d9bf0;
+}


### PR DESCRIPTION
Adds a hover-over info icon to the Date Range section in the sidebar search builder to clarify that it sets a fixed time period and directs users to the Time Window feature for dynamic dates.

Fixes #20

🤖 Generated with [Claude Code](https://claude.ai/code)