### PR TITLE
Fix ESLint warnings and auth setup test failure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -98,8 +98,8 @@ The sidebar (`content/content.js:66-147`) is injected into x.com pages:
 - `tests/page-objects/` - Page object models (PopupPage, SidebarPage)
 - `tests/helpers/` - Test helpers
   - `test-page-helpers.ts` - TestPageHelpers for test page navigation
-  - `x-page-helpers.ts` - XPageHelpers for X.com integration tests (2 tests only)
-- `tests/setup/` - Auth setup for X.com integration tests (rarely needed)
+  - `x-page-helpers.ts` - XPageHelpers for X.com integration tests (optional, for manual testing)
+- `tests/setup/` - Auth setup for X.com integration tests (optional, skips automatically if no credentials)
 
 ### Test Page Architecture
 
@@ -117,10 +117,7 @@ The sidebar (`content/content.js:66-147`) is injected into x.com pages:
 - JavaScript helpers: `window.getTestPageState()`, `window.resetTestPageState()`
 - Search history tracking: `window.__SEARCH_HISTORY__`
 
-**X.com integration tests** (2 tests in `apply-saved-search.spec.ts`):
-- "should apply saved search from sidebar on X.com" - Tests actual search application
-- "should apply sliding window search with fresh dates from sidebar" - Tests sliding window dates on X.com
-- These require `.env` with X.com credentials and may hit rate limits
+**X.com integration tests**: Currently all E2E tests use the test page. The `auth-verification.spec.ts` test is ignored by default since it requires X.com credentials and may hit rate limits.
 
 ### Parallel Test Execution
 
@@ -150,16 +147,12 @@ npx playwright test -g "sliding window"
 
 # Debug specific test
 npx playwright test tests/e2e/workflows/sliding-window.spec.ts --debug
-
-# X.com integration tests only (requires .env)
-npx playwright test tests/e2e/workflows/apply-saved-search.spec.ts -g "on X.com"
 ```
 
 ### E2E Test Requirements
-- **Most E2E tests**: No requirements! Run instantly with test page
-- **X.com integration tests** (2 tests): Require `.env` file with X.com credentials
-- Create placeholder auth file to skip setup: `echo '{}' > tests/.auth/user.json`
-- Never commit `.env` or auth state files
+- **All E2E tests**: No requirements! All tests use the test page and run instantly
+- **X.com auth setup**: Automatically skips if no `.env` credentials provided
+- Never commit `.env` or auth state files if testing against X.com
 
 ## Common Patterns
 
@@ -256,4 +249,3 @@ Total time: ~30-45 seconds with parallel execution (was 2-3 minutes before!). By
 4. Test on x.com or twitter.com
 5. Run `npm test` to verify unit tests
 6. Run `npm run test:e2e:headed` to see E2E tests in action (uses test page, fast!)
-7. X.com integration tests only needed for major releases (run monthly)

--- a/tests/e2e/workflows/apply-saved-search.spec.ts
+++ b/tests/e2e/workflows/apply-saved-search.spec.ts
@@ -1,6 +1,5 @@
 import { test, expect } from '../../fixtures/extension';
 import { SidebarPage } from '../../page-objects/SidebarPage';
-import { XPageHelpers } from '../../helpers/x-page-helpers';
 import { TestPageHelpers } from '../../helpers/test-page-helpers';
 
 test.describe('Workflow 2: Quick Apply Saved Search', () => {

--- a/tests/e2e/workflows/category-colors.spec.ts
+++ b/tests/e2e/workflows/category-colors.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '../../fixtures/extension';
+import { Dialog } from '@playwright/test';
 import { SidebarPage } from '../../page-objects/SidebarPage';
 import { TestPageHelpers } from '../../helpers/test-page-helpers';
 
@@ -20,7 +21,7 @@ test.describe('Category Colors Management', () => {
   });
 
   test.describe('Categories Tab - Category Management Section', () => {
-    test('should display Manage Categories section in Categories tab', async ({ page, extensionId }) => {
+    test('should display Manage Categories section in Categories tab', async ({ page, extensionId: _extensionId }) => {
       const testPageHelper = new TestPageHelpers(page);
       await testPageHelper.navigateToTestPage();
 
@@ -43,7 +44,7 @@ test.describe('Category Colors Management', () => {
       await expect(addButton).toHaveText('Add');
     });
 
-    test('should show all existing categories with color pickers', async ({ page, extensionId }) => {
+    test('should show all existing categories with color pickers', async ({ page, extensionId: _extensionId }) => {
       const testPageHelper = new TestPageHelpers(page);
       await testPageHelper.navigateToTestPage();
 
@@ -73,7 +74,7 @@ test.describe('Category Colors Management', () => {
       expect(hasUncategorized).toBe(true);
     });
 
-    test('should display color indicators', async ({ page, extensionId }) => {
+    test('should display color indicators', async ({ page, extensionId: _extensionId }) => {
       const testPageHelper = new TestPageHelpers(page);
       await testPageHelper.navigateToTestPage();
 
@@ -101,7 +102,7 @@ test.describe('Category Colors Management', () => {
   });
 
   test.describe('Color Picker Interactions', () => {
-    test('should update color display when color changes', async ({ page, extensionId }) => {
+    test('should update color display when color changes', async ({ page, extensionId: _extensionId }) => {
       const testPageHelper = new TestPageHelpers(page);
       await testPageHelper.navigateToTestPage();
 
@@ -140,7 +141,7 @@ test.describe('Category Colors Management', () => {
       expect(newColor).toContain('255'); // Red component
     });
 
-    test('should persist color changes without page reload', async ({ page, extensionId, context }) => {
+    test('should persist color changes without page reload', async ({ page, extensionId: _extensionId, context }) => {
       const testPageHelper = new TestPageHelpers(page);
       await testPageHelper.navigateToTestPage();
 
@@ -182,7 +183,7 @@ test.describe('Category Colors Management', () => {
       await newPage.close();
     });
 
-    test('should update multiple categories independently', async ({ page, extensionId }) => {
+    test('should update multiple categories independently', async ({ page, extensionId: _extensionId }) => {
       const testPageHelper = new TestPageHelpers(page);
       await testPageHelper.navigateToTestPage();
 
@@ -222,21 +223,21 @@ test.describe('Category Colors Management', () => {
   });
 
   test.describe('Reset Functionality', () => {
-    test.skip('should reset all colors to defaults on button click', async ({ page, extensionId }) => {
+    test.skip('should reset all colors to defaults on button click', async ({ page, extensionId: _extensionId }) => {
       // SKIP REASON: Reset functionality was part of old Settings tab design
       // New Categories tab uses individual color pickers without bulk reset
-      await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+      await page.goto(`chrome-extension://${_extensionId}/popup/popup.html`);
     });
 
-    test.skip('should update UI immediately after reset', async ({ page, extensionId }) => {
+    test.skip('should update UI immediately after reset', async ({ page, extensionId: _extensionId }) => {
       // SKIP REASON: Reset functionality was part of old Settings tab design
       // New Categories tab uses individual color pickers without bulk reset
-      await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+      await page.goto(`chrome-extension://${_extensionId}/popup/popup.html`);
     });
   });
 
   test.describe('Visual Validation', () => {
-    test('should display correct border color for saved searches', async ({ page, extensionId, context: _context }) => {
+    test('should display correct border color for saved searches', async ({ page, extensionId: _extensionId, context: _context }) => {
       const testPageHelper = new TestPageHelpers(page);
       await testPageHelper.navigateToTestPage();
 
@@ -270,7 +271,7 @@ test.describe('Category Colors Management', () => {
       expect(borderColor).toContain('255'); // Red component
     });
 
-    test('should maintain custom colors when category colors change', async ({ page, extensionId }) => {
+    test('should maintain custom colors when category colors change', async ({ page, extensionId: _extensionId }) => {
       const testPageHelper = new TestPageHelpers(page);
       await testPageHelper.navigateToTestPage();
 
@@ -286,7 +287,7 @@ test.describe('Category Colors Management', () => {
       await page.selectOption('#sidebarSearchCategory', 'Coding');
       await page.waitForTimeout(200);
 
-      const dialogHandler = async (dialog: any) => {
+      const dialogHandler = async (dialog: Dialog) => {
         await dialog.accept('Custom Color Test');
       };
 
@@ -305,10 +306,10 @@ test.describe('Category Colors Management', () => {
   });
 
   test.describe('Category Color Inheritance', () => {
-    test.skip('new searches should inherit current category color', async ({ page, extensionId }) => {
+    test.skip('new searches should inherit current category color', async ({ page, extensionId: _extensionId }) => {
       // SKIP REASON: Complex dialog flow with multiple prompts/alerts is difficult to test reliably in e2e
       // This functionality is covered by unit tests in storage.spec.ts
-      await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+      await page.goto(`chrome-extension://${_extensionId}/popup/popup.html`);
 
       // Set a specific color for Technology category
       const settingsTab = page.locator('[data-tab="settings"]');
@@ -358,7 +359,7 @@ test.describe('Category Colors Management', () => {
       const savedSearch = await page.evaluate(async () => {
         const result = await chrome.storage.sync.get(['savedSearches']);
         const searches = result.savedSearches || [];
-        return searches.find((s: any) => s.name === 'Technology Color Test');
+        return searches.find((s: { name: string }) => s.name === 'Technology Color Test');
       });
 
       expect(savedSearch).toBeDefined();
@@ -369,10 +370,10 @@ test.describe('Category Colors Management', () => {
 });
 
 test.describe('Integration Flow', () => {
-  test.skip('complete user flow with category colors', async ({ page, extensionId }) => {
+  test.skip('complete user flow with category colors', async ({ page, extensionId: _extensionId }) => {
     // SKIP REASON: Complex dialog flow with multiple prompts/alerts is difficult to test reliably in e2e
     // This functionality is covered by unit tests in storage.spec.ts
-    await page.goto(`chrome-extension://${extensionId}/popup/popup.html`);
+    await page.goto(`chrome-extension://${_extensionId}/popup/popup.html`);
 
     // Step 1: Change color in settings
     const settingsTab = page.locator('[data-tab="settings"]');

--- a/tests/mocks/chrome-api.ts
+++ b/tests/mocks/chrome-api.ts
@@ -1,5 +1,5 @@
 interface MockStorageData {
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 interface MockTab {
@@ -40,7 +40,7 @@ export class MockChromeTabs {
   private tabs: MockTab[] = [];
   private nextTabId = 1;
 
-  async query(options: any): Promise<MockTab[]> {
+  async query(options: { url?: string | string[]; active?: boolean }): Promise<MockTab[]> {
     let filtered = [...this.tabs];
 
     if (options.url) {
@@ -60,7 +60,7 @@ export class MockChromeTabs {
     return filtered;
   }
 
-  async update(tabId: number, updateInfo: any): Promise<MockTab | undefined> {
+  async update(tabId: number, updateInfo: Partial<MockTab>): Promise<MockTab | undefined> {
     const tab = this.tabs.find(t => t.id === tabId);
     if (tab) {
       Object.assign(tab, updateInfo);
@@ -80,7 +80,7 @@ export class MockChromeTabs {
     return newTab;
   }
 
-  async sendMessage(_tabId: number, _message: any): Promise<any> {
+  async sendMessage(_tabId: number, _message: unknown): Promise<{ success: boolean }> {
     return { success: true };
   }
 
@@ -107,25 +107,25 @@ export class MockChromeTabs {
 }
 
 export class MockChromeWindows {
-  async update(windowId: number, updateInfo: any): Promise<any> {
+  async update(windowId: number, updateInfo: Record<string, unknown>): Promise<Record<string, unknown>> {
     return { id: windowId, ...updateInfo };
   }
 }
 
 export class MockChromeRuntime {
-  private messageListeners: Array<(message: any, sender: any, sendResponse: any) => void> = [];
+  private messageListeners: Array<(message: unknown, sender: unknown, sendResponse: (response: unknown) => void) => void> = [];
 
   onMessage = {
-    addListener: (callback: (message: any, sender: any, sendResponse: any) => void) => {
+    addListener: (callback: (message: unknown, sender: unknown, sendResponse: (response: unknown) => void) => void) => {
       this.messageListeners.push(callback);
     }
   };
 
-  async sendMessage(_message: any): Promise<any> {
+  async sendMessage(_message: unknown): Promise<{ success: boolean }> {
     return { success: true };
   }
 
-  triggerMessage(message: any, sender: any = {}) {
+  triggerMessage(message: unknown, sender: Record<string, unknown> = {}) {
     this.messageListeners.forEach(listener => {
       listener(message, sender, () => {});
     });

--- a/tests/page-objects/SidebarPage.ts
+++ b/tests/page-objects/SidebarPage.ts
@@ -1,4 +1,4 @@
-import { Page, expect } from '@playwright/test';
+import { Page, expect, Dialog } from '@playwright/test';
 
 export class SidebarPage {
   constructor(private page: Page) {}
@@ -9,7 +9,7 @@ export class SidebarPage {
     try {
       // First attempt: wait for sidebar to appear
       await expect(sidebarToggle).toBeVisible({ timeout });
-    } catch (error) {
+    } catch {
       // Retry: reload page and wait again
       console.log('Sidebar not found, reloading page and retrying...');
       await this.page.reload({ waitUntil: 'networkidle' });
@@ -315,7 +315,7 @@ export class SidebarPage {
       await this.page.waitForTimeout(200);
     }
 
-    const dialogHandler = async (dialog: any) => {
+    const dialogHandler = async (dialog: Dialog) => {
       await dialog.accept(name);
     };
 

--- a/tests/setup/auth.setup.ts
+++ b/tests/setup/auth.setup.ts
@@ -17,12 +17,16 @@ setup('authenticate with X.com', async ({ }) => {
     return;
   }
 
+  // Skip if credentials not provided
+  if (!process.env.TEST_X_USERNAME || !process.env.TEST_X_PASSWORD) {
+    console.log('⚠ Skipping X.com authentication - no credentials in .env file');
+    console.log('  (Add TEST_X_USERNAME and TEST_X_PASSWORD to .env to enable X.com tests)');
+    setup.skip();
+    return;
+  }
+
   // Ensure user data directory exists
   fs.mkdirSync(userDataDir, { recursive: true });
-
-  if (!process.env.TEST_X_USERNAME || !process.env.TEST_X_PASSWORD) {
-    throw new Error('TEST_X_USERNAME and TEST_X_PASSWORD must be set in .env file');
-  }
 
   console.log('\n━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━');
   console.log('  X.com Automated Authentication');

--- a/tests/unit/query-builder.spec.ts
+++ b/tests/unit/query-builder.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import path from 'path';
 
 test.describe('QueryBuilder Unit Tests', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let QueryBuilder: any;
 
   test.beforeAll(async () => {

--- a/tests/unit/storage.spec.ts
+++ b/tests/unit/storage.spec.ts
@@ -3,12 +3,15 @@ import { createMockChrome } from '../mocks/chrome-api';
 import { mockSearches, mockSettings, mockCategoryColors, mockSearchesWithCustomColors } from '../fixtures/test-data';
 
 test.describe('StorageManager Unit Tests', () => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let StorageManager: any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mockChrome: any;
 
   test.beforeEach(async () => {
     mockChrome = createMockChrome();
     mockChrome.storage.sync.clear();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     global.chrome = mockChrome as any;
 
     delete require.cache[require.resolve('../../lib/storage.js')];
@@ -16,6 +19,7 @@ test.describe('StorageManager Unit Tests', () => {
   });
 
   test.afterEach(() => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     delete (global as any).chrome;
   });
 
@@ -146,7 +150,7 @@ test.describe('StorageManager Unit Tests', () => {
 
       const searches = await StorageManager.getSavedSearches();
       expect(searches.length).toBe(2);
-      expect(searches.find((s: any) => s.id === mockSearches[1].id)).toBeUndefined();
+      expect(searches.find((s: { id: string }) => s.id === mockSearches[1].id)).toBeUndefined();
     });
 
     test('should return true even if ID doesn\'t exist', async () => {
@@ -569,10 +573,10 @@ test.describe('StorageManager Unit Tests', () => {
       expect(result.searchesMoved).toBe(2);
 
       const searches = await StorageManager.getSavedSearches();
-      const movedSearches = searches.filter((s: any) => s.id === search1.id || s.id === search2.id);
+      const movedSearches = searches.filter((s: { id: string }) => s.id === search1.id || s.id === search2.id);
       const uncategorizedColor = await StorageManager.getCategoryColor('Uncategorized');
 
-      movedSearches.forEach((s: any) => {
+      movedSearches.forEach((s: { id: string; category: string; color: string }) => {
         expect(s.category).toBe('Uncategorized');
         expect(s.color).toBe(uncategorizedColor);
       });
@@ -604,8 +608,8 @@ test.describe('StorageManager Unit Tests', () => {
       expect(result.searchesMoved).toBe(2);
 
       const searches = await StorageManager.getSavedSearches();
-      const customColorSearch = searches.find((s: any) => s.id === searchWithCustomColor.id);
-      const categoryColorSearch = searches.find((s: any) => s.id === searchWithCategoryColor.id);
+      const customColorSearch = searches.find((s: { id: string }) => s.id === searchWithCustomColor.id);
+      const categoryColorSearch = searches.find((s: { id: string }) => s.id === searchWithCategoryColor.id);
       const uncategorizedColor = await StorageManager.getCategoryColor('Uncategorized');
 
       expect(customColorSearch.category).toBe('Uncategorized');
@@ -673,8 +677,8 @@ test.describe('StorageManager Unit Tests', () => {
       expect(result.searchesUpdated).toBe(2);
 
       const searches = await StorageManager.getSavedSearches();
-      const renamedSearches = searches.filter((s: any) => s.id === search1.id || s.id === search2.id);
-      renamedSearches.forEach((s: any) => {
+      const renamedSearches = searches.filter((s: { id: string }) => s.id === search1.id || s.id === search2.id);
+      renamedSearches.forEach((s: { id: string; category: string }) => {
         expect(s.category).toBe('Renamed');
       });
     });

--- a/tests/unit/templates.spec.ts
+++ b/tests/unit/templates.spec.ts
@@ -3,6 +3,14 @@ import { test, expect } from '@playwright/test';
 const { DefaultTemplates, initializeTemplates } = require('../../lib/templates');
 const QueryBuilder = require('../../lib/query-builder');
 
+interface Template {
+  name: string;
+  description: string;
+  category: string;
+  color: string;
+  filters: Record<string, unknown>;
+}
+
 test.describe('Templates Unit Tests', () => {
   test.describe('DefaultTemplates', () => {
     test('should have 3 default templates', () => {
@@ -10,7 +18,7 @@ test.describe('Templates Unit Tests', () => {
     });
 
     test('should have required fields in all templates', () => {
-      DefaultTemplates.forEach((template: any) => {
+      DefaultTemplates.forEach((template: Template) => {
         expect(template).toHaveProperty('name');
         expect(template).toHaveProperty('description');
         expect(template).toHaveProperty('category');
@@ -26,13 +34,13 @@ test.describe('Templates Unit Tests', () => {
 
     test('should have valid color codes', () => {
       const colorRegex = /^#[0-9a-f]{6}$/i;
-      DefaultTemplates.forEach((template: any) => {
+      DefaultTemplates.forEach((template: Template) => {
         expect(template.color).toMatch(colorRegex);
       });
     });
 
     test('should have "claude code" template', () => {
-      const claudeTemplate = DefaultTemplates.find((t: any) => t.name === 'claude code');
+      const claudeTemplate = DefaultTemplates.find((t: Template) => t.name === 'claude code');
       expect(claudeTemplate).toBeDefined();
       expect(claudeTemplate?.filters.keywords).toBe('claude code');
       expect(claudeTemplate?.filters.slidingWindow).toBe('1w');
@@ -40,7 +48,7 @@ test.describe('Templates Unit Tests', () => {
     });
 
     test('should have "chrome extension" template', () => {
-      const chromeTemplate = DefaultTemplates.find((t: any) => t.name === 'chrome extension');
+      const chromeTemplate = DefaultTemplates.find((t: Template) => t.name === 'chrome extension');
       expect(chromeTemplate).toBeDefined();
       expect(chromeTemplate?.filters.keywords).toBe('chrome extension');
       expect(chromeTemplate?.filters.slidingWindow).toBe('1m');
@@ -48,19 +56,19 @@ test.describe('Templates Unit Tests', () => {
     });
 
     test('should have unique template names', () => {
-      const names = DefaultTemplates.map((t: any) => t.name);
+      const names = DefaultTemplates.map((t: Template) => t.name);
       const uniqueNames = new Set(names);
       expect(uniqueNames.size).toBe(DefaultTemplates.length);
     });
 
     test('should have templates in different categories', () => {
-      const categories = DefaultTemplates.map((t: any) => t.category);
+      const categories = DefaultTemplates.map((t: Template) => t.category);
       const uniqueCategories = new Set(categories);
       expect(uniqueCategories.size).toBeGreaterThan(1);
     });
 
     test('should build valid queries from template filters', () => {
-      DefaultTemplates.forEach((template: any) => {
+      DefaultTemplates.forEach((template: Template) => {
         const query = new QueryBuilder().fromFilters(template.filters).build();
         expect(typeof query).toBe('string');
         expect(query.length).toBeGreaterThan(0);
@@ -71,19 +79,23 @@ test.describe('Templates Unit Tests', () => {
   test.describe('initializeTemplates', () => {
     test('should skip initialization if chrome.storage is not available', async () => {
       const originalChrome = global.chrome;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       delete (global as any).chrome;
 
       await initializeTemplates();
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (global as any).chrome = originalChrome;
     });
 
     test('should skip initialization if chrome.storage.sync is not available', async () => {
       const originalChrome = global.chrome;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (global as any).chrome = {};
 
       await initializeTemplates();
 
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (global as any).chrome = originalChrome;
     });
   });


### PR DESCRIPTION
## ESLint Fixes (45 warnings → 0)

### Unused Variables/Imports
- Remove unused XPageHelpers import in apply-saved-search.spec.ts
- Prefix unused extensionId parameters with underscore in category-colors.spec.ts
- Remove unused error parameter in SidebarPage.ts catch block

### Type Safety Improvements
- Replace 'any' types with proper TypeScript types throughout test files
- Add Dialog type from @playwright/test for dialog handlers
- Create Template interface for template objects
- Improve mock Chrome API types (unknown, proper interfaces, return types)
- Add inline callback types: { id: string }, { name: string }, etc.
- Add ESLint disable comments for legitimate 'any' uses (dynamic imports, global mocks)

## X.com Auth Setup Fix
- Change auth.setup.ts to skip gracefully when credentials missing instead of throwing error
- Add helpful console messages explaining skip reason
- Move directory creation after credentials check

## Documentation Updates (CLAUDE.md)
- Remove references to non-existent "2 X.com integration tests"
- Update test requirements to clarify all E2E tests use test page
- Update auth setup description to "optional, skips automatically"
- Remove outdated X.com integration test examples

## Test Results
- ✅ Linting: 0 errors, 0 warnings (was 45 warnings)
- ✅ TypeScript: 0 errors
- ✅ Unit tests: 148/148 passed
- ✅ E2E tests: 216 passed, 6 skipped (including graceful auth skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)