### PR TITLE
feat: improve UI messaging and sidebar behavior

### DIFF
--- a/content/content.js
+++ b/content/content.js
@@ -144,7 +144,7 @@ async function initializeSidebar() {
             <section class="form-section">
               <h3>
                 Keywords
-                <span class="info-icon" data-tooltip="Keywords use X's search - case-sensitive, respects punctuation">
+                <span class="info-icon" data-tooltip="Exact search only - matches as entered into X's search (no wildcards or fuzzy matching)">
                   <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
                     <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
                     <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
@@ -188,8 +188,8 @@ async function initializeSidebar() {
             <section class="form-section collapsible">
               <h3 class="section-header">
                 <span>
-                  Time Window
-                  <span class="info-icon" data-tooltip="Dynamic time ranges that auto-update. 'Last 1 Week' always shows posts from the past 7 days.">
+                  Sliding Time Window
+                  <span class="info-icon" data-tooltip="Auto-updating time windows. 'Last 1 Week' always searches the past 7 days from today when applied.">
                     <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
                       <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
                       <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
@@ -200,7 +200,7 @@ async function initializeSidebar() {
               </h3>
               <div class="section-content">
                 <div class="input-group">
-                  <label>Dynamic Time Range</label>
+                  <label>Sliding Window Period</label>
                   <select id="sidebarSlidingWindow">
                     <option value="">None (use fixed dates below)</option>
                     <option value="1d">Last 1 Day</option>
@@ -209,7 +209,7 @@ async function initializeSidebar() {
                   </select>
                 </div>
                 <div class="setting-info" id="sidebarSlidingWindowInfo" style="display: none; margin-top: 8px;">
-                  <p style="font-size: 11px; color: #6b7280; line-height: 1.4;">🕒 <strong>Dynamic time range:</strong> This search automatically updates each time you use it. For example, "Last 1 Week" always shows posts from the past 7 days starting from today. Unlike X's fixed date ranges, this always returns fresh, recent content.</p>
+                  <p style="font-size: 11px; color: #6b7280; line-height: 1.4;">🕒 <strong>Sliding time window:</strong> This search automatically updates each time you apply it. For example, "Last 1 Week" always searches the past 7 days from today, ensuring fresh, recent results every time.</p>
                 </div>
               </div>
             </section>
@@ -218,7 +218,7 @@ async function initializeSidebar() {
               <h3 class="section-header">
                 <span>
                   Date Range
-                  <span class="info-icon" data-tooltip="Fixed time period. For auto-updating dates, use Time Window above.">
+                  <span class="info-icon" data-tooltip="Fixed dates that don't change. For auto-updating searches, use Sliding Time Window above.">
                     <svg viewBox="0 0 16 16" width="14" height="14" fill="currentColor">
                       <path d="M8 15A7 7 0 1 1 8 1a7 7 0 0 1 0 14zm0 1A8 8 0 1 0 8 0a8 8 0 0 0 0 16z"/>
                       <path d="m8.93 6.588-2.29.287-.082.38.45.083c.294.07.352.176.288.469l-.738 3.468c-.194.897.105 1.319.808 1.319.545 0 1.178-.252 1.465-.598l.088-.416c-.2.176-.492.246-.686.246-.275 0-.375-.193-.304-.533L8.93 6.588zM9 4.5a1 1 0 1 1-2 0 1 1 0 0 1 2 0z"/>
@@ -436,9 +436,6 @@ async function initializeSidebar() {
                   <span>Blog</span>
                 </a>
               </div>
-              <p class="about-creator">
-                Created by <a href="https://x.com/neonwatty" target="_blank" rel="noopener noreferrer">neonwatty</a>
-              </p>
             </div>
           </div>
         </div>
@@ -654,9 +651,6 @@ async function loadSidebarSearches() {
         }
 
         applySearchToPage(query);
-        sidebarVisible = false;
-        await chrome.storage.sync.set({ sidebarVisible: false });
-        updateSidebarVisibility();
       }
     });
   });
@@ -1013,7 +1007,7 @@ function updateSidebarQueryPreview() {
 
   if (query) {
     preview.textContent = query;
-    preview.style.color = '#1e3a8a';
+    preview.style.color = '#60a5fa';
     previewContainer.classList.remove('disabled');
   } else {
     preview.textContent = 'Enter search criteria above...';

--- a/content/sidebar.css
+++ b/content/sidebar.css
@@ -157,7 +157,8 @@
   color: #71767b;
   cursor: pointer;
   font-size: 12px;
-  font-weight: 600;
+  font-weight: 500;
+  letter-spacing: -0.3px;
   border-bottom: 2px solid transparent;
   transition: all 0.2s;
   min-width: 0;
@@ -738,7 +739,7 @@
 .query-hint {
   font-size: 11px;
   color: #1d9bf0;
-  opacity: 0;
+  opacity: 1;
   transition: opacity 0.2s;
 }
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "X Search Pro",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Build your personal X/Twitter search library. Save, categorize, color-code, and organize searches you use repeatedly.",
   "permissions": [
     "storage",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "x-search-pro",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Chrome extension with smart X/Twitter searches that auto-update their time ranges",
   "scripts": {
     "prepare": "husky",

--- a/popup/popup.html
+++ b/popup/popup.html
@@ -40,11 +40,12 @@
 
         <div class="about-notice">
           <h3>💡 How to Use X Search Pro</h3>
-          <p>All search building and management features are now in the <strong>sidebar on X.com</strong>:</p>
+          <p>Build powerful X/Twitter searches with advanced filters and sliding time windows — all from the <strong>sidebar on X.com</strong>:</p>
           <ul>
             <li><strong>Builder</strong> - Create custom searches with advanced filters</li>
             <li><strong>Saved Searches</strong> - Access and apply your saved searches</li>
             <li><strong>Categories</strong> - Organize searches by category</li>
+            <li><strong>Settings</strong> - Toggle sidebar visibility on/off</li>
           </ul>
           <p class="sidebar-hint">👉 Look for the toggle button on the right edge of X.com to open the sidebar.</p>
         </div>

--- a/tests/e2e/workflows/apply-saved-search.spec.ts
+++ b/tests/e2e/workflows/apply-saved-search.spec.ts
@@ -32,7 +32,7 @@ test.describe('Workflow 2: Quick Apply Saved Search', () => {
 
     await page.waitForTimeout(2000);
 
-    await expect(await sidebar.isVisible()).toBe(false);
+    await expect(await sidebar.isVisible()).toBe(true);
 
     // Verify search was applied to the input
     const searchInputValue = await testPageHelper.getSearchInputValue();
@@ -68,7 +68,7 @@ test.describe('Workflow 2: Quick Apply Saved Search', () => {
     await page.close();
   });
 
-  test('should close sidebar after applying search', async ({ context, extensionId: _extensionId }) => {
+  test('should keep sidebar open after applying search', async ({ context, extensionId: _extensionId }) => {
     const page = await context.newPage();
     const testPageHelper = new TestPageHelpers(page);
 
@@ -85,7 +85,7 @@ test.describe('Workflow 2: Quick Apply Saved Search', () => {
     if (await searches.count() > 0) {
       await searches.first().click();
       await page.waitForTimeout(2000);
-      await expect(await sidebar.isVisible()).toBe(false);
+      await expect(await sidebar.isVisible()).toBe(true);
     }
 
     await page.waitForTimeout(1000);
@@ -281,8 +281,8 @@ test.describe('Sidebar: Sliding Window Display', () => {
         await search.click();
         await page.waitForTimeout(2000);
 
-        // Sidebar should close
-        await expect(await sidebar.isVisible()).toBe(false);
+        // Sidebar should remain open
+        await expect(await sidebar.isVisible()).toBe(true);
 
         // Verify search was applied with date filters
         const searchInputValue = await testPageHelper.getSearchInputValue();


### PR DESCRIPTION
- Update sidebar builder tooltips for clarity:
  - Keywords: emphasize exact search behavior
  - Sliding Time Window: rename from "Time Window" and update messaging
  - Date Range: update to reference new sliding window terminology
- Improve query preview visibility:
  - Change query text color from dark blue (#1e3a8a) to lighter blue (#60a5fa)
  - Make "Click to try" hint always visible
- Fix Categories tab text truncation:
  - Reduce font-weight from 600 to 500
  - Add letter-spacing: -0.3px for condensed text
- Keep sidebar open after applying saved searches (previously auto-closed)
- Update popup About tab with succinct intro and Settings bullet point
- Remove duplicate "Created by neonwatty" from sidebar About tab
- Update tests to expect sidebar to remain open after applying searches
