### PR TITLE
fix: make color selector square in Add New Category

### DIFF
--- a/content/sidebar.css
+++ b/content/sidebar.css
@@ -929,7 +929,7 @@
 }
 
 .color-picker-small {
-  width: 40px;
+  width: 34px;
   height: 34px;
   border: none;
   border-radius: 6px;


### PR DESCRIPTION
Adjusted the color-picker-small width from 40px to 34px to create
a square color selector (34x34) that matches the style of color
selectors in the "Your Categories" section.

Fixes #32

🤖 Generated with [Claude Code](https://claude.ai/code)